### PR TITLE
Allow custom ns prefix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,8 +84,8 @@ dependencies {
 }
 
 tasks.withType(JavaCompile) {
-    sourceCompatibility = '1.6'
-    targetCompatibility = '1.6'
+    sourceCompatibility = '1.7'
+    targetCompatibility = '1.7'
 
     options.encoding = "UTF-8"
     options.compilerArgs << "-Xlint:-options"

--- a/src/main/java/neustar/registry/jtoolkit2/xml/NamespaceContextImpl.java
+++ b/src/main/java/neustar/registry/jtoolkit2/xml/NamespaceContextImpl.java
@@ -39,8 +39,8 @@ public final class NamespaceContextImpl implements NamespaceContext {
          * No definite answer on why EPP has 2 prefixes, but it has been suggested that this may have to do with
          * compatibility with the old toolkits.
          */
-        NamespaceContextImpl.put("e", "urn:ietf:params:xml:ns:epp-1.0");
         NamespaceContextImpl.put("epp", "urn:ietf:params:xml:ns:epp-1.0");
+        NamespaceContextImpl.put("e", "urn:ietf:params:xml:ns:epp-1.0");
         for (StandardObjectType standardObjectType : StandardObjectType.values()) {
             NamespaceContextImpl.put(standardObjectType.getName(), standardObjectType.getURI());
         }
@@ -115,7 +115,8 @@ public final class NamespaceContextImpl implements NamespaceContext {
     @Override
     public String getPrefix(String namespaceURI) {
         if (uriPrefixMap.keySet().contains(namespaceURI)) {
-            return uriPrefixMap.get(namespaceURI).get(0);
+            List<String> prefixes = uriPrefixMap.get(namespaceURI);
+            return prefixes.get(prefixes.size() - 1);
         }
 
         return null;


### PR DESCRIPTION
1. Allow custom prefixes to be used while generating EPP XML.
2. Updated Java compatibility version to 1.7